### PR TITLE
fix hook static method

### DIFF
--- a/java/com/lody/whale/xposed/XposedBridge.java
+++ b/java/com/lody/whale/xposed/XposedBridge.java
@@ -98,6 +98,7 @@ public final class XposedBridge {
         callbacks.add(callback);
 
         if (newMethod) {
+            XposedHelpers.resolveStaticMethod(hookMethod);
             AdditionalHookInfo additionalInfo = new AdditionalHookInfo(callbacks);
             long slot = WhaleRuntime.hookMethodNative(hookMethod.getDeclaringClass(), hookMethod, additionalInfo);
             if (slot <= 0) {

--- a/java/com/lody/whale/xposed/XposedHelpers.java
+++ b/java/com/lody/whale/xposed/XposedHelpers.java
@@ -1837,6 +1837,28 @@ public final class XposedHelpers {
         return methods;
     }
 
+    /**
+     * the static method is lazy resolved, when not resolved, the entry point is a trampoline of
+     * a bridge, we can not hook these entry. this method force the static method to be resolved.
+     */
+    public static void resolveStaticMethod(Member method) {
+        //ignore result, just call to trigger resolve
+        if (method == null)
+            return;
+        try {
+            if (method instanceof Method && Modifier.isStatic(method.getModifiers())) {
+                ((Method) method).setAccessible(true);
+                ((Method) method).invoke(new Object(), getFakeArgs((Method) method));
+            }
+        } catch (Exception ignored) {
+            // we should never make a successful call.
+        }
+    }
+
+    private static Object[] getFakeArgs(Method method) {
+        return method.getParameterTypes().length == 0 ? new Object[]{new Object()} : null;
+    }
+
     //#################################################################################################
     // TODO helpers for view traversing
     /*To make it easier, I will try and implement some more helpers:

--- a/whale/src/android/art/art_runtime.cc
+++ b/whale/src/android/art/art_runtime.cc
@@ -191,9 +191,6 @@ ArtRuntime::HookMethod(JNIEnv *env, jclass decl_class, jobject hooked_java_metho
     ArtMethod hooked_method(hooked_jni_method);
     auto *param = new ArtHookParam();
 
-    param->origin_compiled_code_ = hooked_method.GetEntryPointFromQuickCompiledCode();
-    param->origin_code_item_off = hooked_method.GetDexCodeItemOffset();
-    param->origin_jni_code_ = hooked_method.GetEntryPointFromJni();
     param->class_Loader_ = env->NewGlobalRef(
             env->CallObjectMethod(
                     decl_class,
@@ -203,10 +200,11 @@ ArtRuntime::HookMethod(JNIEnv *env, jclass decl_class, jobject hooked_java_metho
     param->shorty_ = hooked_method.GetShorty(env, hooked_java_method);
     param->is_static_ = hooked_method.HasAccessFlags(kAccStatic);
 
-    if (param->is_static_) {
-        EnsureClassInitialized(env, decl_class);
-    }
-    jobject origin_java_method = hooked_method.Clone(env, hooked_method.GetAccessFlags());
+    param->origin_compiled_code_ = hooked_method.GetEntryPointFromQuickCompiledCode();
+    param->origin_code_item_off = hooked_method.GetDexCodeItemOffset();
+    param->origin_jni_code_ = hooked_method.GetEntryPointFromJni();
+    param->origin_access_flags = hooked_method.GetAccessFlags();
+    jobject origin_java_method = hooked_method.Clone(env, param->origin_access_flags);
 
     ResolvedSymbols *symbols = GetSymbols();
     if (symbols->ProfileSaver_ForceProcessProfiles) {


### PR DESCRIPTION
hook方法时忘记把原方法的access_flags赋值给ArtHookParam的origin_access_flags属性，导致MovingGC之后，Clone时静态方法变为了对象方法，出现null receiver problem。EnsureClassInitialized未能解决static method未resolved。