### PR TITLE
add sync for MovingGC Clone

### DIFF
--- a/whale/src/android/art/art_hook_param.h
+++ b/whale/src/android/art/art_hook_param.h
@@ -18,7 +18,7 @@ struct ArtHookParam final {
     u4 origin_code_item_off;
     jobject origin_method_;
     jobject hooked_method_;
-    ptr_t decl_class_;
+    volatile ptr_t decl_class_;
     jobject class_Loader_;
     jmethodID hooked_native_method_;
     jmethodID origin_native_method_;

--- a/whale/src/android/art/art_jni_trampoline.cc
+++ b/whale/src/android/art/art_jni_trampoline.cc
@@ -12,6 +12,10 @@ namespace whale {
 namespace art {
 
 static void UnBoxValue(JNIEnv *env, jvalue *jv, jobject obj, char type) {
+    if (obj == nullptr) {
+        jv->l = obj;
+        return;
+    }
     switch (type) {
         case 'I':
             jv->i = Types::FromInteger(env, obj);

--- a/whale/src/android/art/art_runtime.h
+++ b/whale/src/android/art/art_runtime.h
@@ -137,6 +137,7 @@ class ArtRuntime final {
     ClassLinkerObjects class_linker_objects_;
     ArtMethodOffsets method_offset_;
     std::map<jmethodID, ArtHookParam *> hooked_method_map_;
+    pthread_mutex_t mutex;
 
     bool EnforceDisableHiddenAPIPolicyImpl();
 


### PR DESCRIPTION
在hook多线程并发执行的函数时，在MovingGC之后，有几率出现多线程同时执行Clone，导致应用卡死。
在hook返回类型为基本类型的函数时，在beforeHookedMethod中直接setResult(null)时，UnBoxValue会出现空指针。