### PR TITLE
fix: use RAX register to reduce code byte length from 13 to 12

### DIFF
--- a/whale/src/dbi/x86_64/inline_hook_x86_64.cc
+++ b/whale/src/dbi/x86_64/inline_hook_x86_64.cc
@@ -16,8 +16,8 @@ void X86_64InlineHook::StartHook() {
     CHECK(address_ != 0 && replace_ != 0);
     X86_64Assembler masm;
 
-    __ movq(R12, Immediate(replace_));
-    __ jmp(R12);
+    __ movq(RAX, Immediate(replace_));
+    __ jmp(RAX);
     masm.FinalizeCode();
 
     size_t backup_size = masm.GetBuffer()->Size();


### PR DESCRIPTION
The jump code causing a problen in the edxposed project, effecting some x86_64 device 
https://github.com/ElderDrivers/EdXposed
I made a fix by change the register name.

Anyway, a shorter jump code is better. 

https://github.com/ElderDrivers/EdXposed/issues/376#issuecomment-547832676